### PR TITLE
feat: add user creation endpoint

### DIFF
--- a/app/src/controllers/api_v1.py
+++ b/app/src/controllers/api_v1.py
@@ -1,5 +1,7 @@
 from fastapi import APIRouter
 from app.src.controllers.items_controller import router as items_router
+from app.src.controllers.users_controller import router as users_router
 
 api_router = APIRouter()
 api_router.include_router(items_router, prefix="/items", tags=["items"])
+api_router.include_router(users_router, prefix="/users", tags=["users"])

--- a/app/src/controllers/users_controller.py
+++ b/app/src/controllers/users_controller.py
@@ -1,0 +1,25 @@
+from fastapi import APIRouter, Depends
+from app.src.models.user import UserCreate, UserOut
+from app.src.services.users_service import UsersService
+
+
+router = APIRouter()
+
+
+def get_users_service() -> UsersService:  # pragma: no cover - replaced at runtime
+    raise NotImplementedError
+
+
+def _to_user_out(doc: dict) -> UserOut:
+    return UserOut(id=str(doc.get("_id") or doc.get("id")), name=doc["name"], email=doc["email"])
+
+
+@router.post("", response_model=str)
+async def create_user(payload: UserCreate, svc: UsersService = Depends(get_users_service)) -> str:
+    return await svc.create(payload)
+
+
+@router.get("/{user_id}", response_model=UserOut | None)
+async def get_user(user_id: str, svc: UsersService = Depends(get_users_service)) -> UserOut | None:
+    doc = await svc.get(user_id)
+    return None if not doc else _to_user_out(doc)

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -5,33 +5,46 @@ from app.src.helpers.logging import configure_logging
 from app.src.controllers.api_v1 import api_router
 from app.src.services.repositories.mongo_items_repository import MongoItemsRepository
 from app.src.services.items_service import ItemsService
+from app.src.services.repositories.mongo_users_repository import MongoUsersRepository
+from app.src.services.users_service import UsersService
 import app.src.controllers.items_controller as items_controller
+import app.src.controllers.users_controller as users_controller
 
 app = FastAPI(title=settings.APP_NAME)
 configure_logging()
 
 mongo_client: AsyncIOMotorClient | None = None
 
+
 @app.on_event("startup")
 async def startup() -> None:
     global mongo_client
     mongo_client = AsyncIOMotorClient(settings.MONGO_URI)
-    repo = MongoItemsRepository(mongo_client, settings.MONGO_DB)
-    svc = ItemsService(repo)
+    items_repo = MongoItemsRepository(mongo_client, settings.MONGO_DB)
+    items_svc = ItemsService(items_repo)
+    users_repo = MongoUsersRepository(mongo_client, settings.MONGO_DB)
+    users_svc = UsersService(users_repo)
 
-    def _provider() -> ItemsService:
-        return svc
+    def _items_provider() -> ItemsService:
+        return items_svc
+
+    def _users_provider() -> UsersService:
+        return users_svc
 
     # simple dependency injection
-    items_controller.get_items_service = _provider  # type: ignore[attr-defined]
+    items_controller.get_items_service = _items_provider  # type: ignore[attr-defined]
+    users_controller.get_users_service = _users_provider  # type: ignore[attr-defined]
+
 
 @app.on_event("shutdown")
 async def shutdown() -> None:
     if mongo_client:
         mongo_client.close()
 
+
 @app.get("/health")
 async def health() -> dict[str, str]:
     return {"status": "ok"}
+
 
 app.include_router(api_router, prefix=settings.API_V1_PREFIX)

--- a/app/src/models/user.py
+++ b/app/src/models/user.py
@@ -1,0 +1,12 @@
+from app.src.models.base import APIModel
+
+
+class UserCreate(APIModel):
+    name: str
+    email: str
+
+
+class UserOut(APIModel):
+    id: str
+    name: str
+    email: str

--- a/app/src/services/items_service.py
+++ b/app/src/services/items_service.py
@@ -1,9 +1,10 @@
 from typing import List, Dict, Any
-from app.src.services.repositories.mongo_items_repository import MongoItemsRepository
+from app.src.domain.repositories import RepositoryProtocol
 from app.src.models.item import ItemCreate, ItemUpdate
 
+
 class ItemsService:
-    def __init__(self, repo: MongoItemsRepository):
+    def __init__(self, repo: RepositoryProtocol):
         self.repo = repo
 
     async def create(self, payload: ItemCreate) -> str:

--- a/app/src/services/repositories/mongo_users_repository.py
+++ b/app/src/services/repositories/mongo_users_repository.py
@@ -1,0 +1,20 @@
+from typing import Optional, Dict, Any
+from motor.motor_asyncio import AsyncIOMotorClient
+from bson import ObjectId
+
+
+class MongoUsersRepository:
+    def __init__(self, client: AsyncIOMotorClient, db_name: str):
+        self._db = client[db_name]
+        self._col = self._db["users"]
+
+    async def get_by_id(self, id: str) -> Optional[Dict[str, Any]]:
+        try:
+            _id = ObjectId(id)
+        except Exception:
+            return None
+        return await self._col.find_one({"_id": _id})
+
+    async def create(self, data: Dict[str, Any]) -> str:
+        res = await self._col.insert_one(data)
+        return str(res.inserted_id)

--- a/app/src/services/users_service.py
+++ b/app/src/services/users_service.py
@@ -1,0 +1,14 @@
+from typing import Dict, Any
+from app.src.domain.repositories import RepositoryProtocol
+from app.src.models.user import UserCreate
+
+
+class UsersService:
+    def __init__(self, repo: RepositoryProtocol):
+        self.repo = repo
+
+    async def create(self, payload: UserCreate) -> str:
+        return await self.repo.create(payload.model_dump())
+
+    async def get(self, user_id: str) -> Dict[str, Any] | None:
+        return await self.repo.get_by_id(user_id)

--- a/app/tests/test_items_controller.py
+++ b/app/tests/test_items_controller.py
@@ -1,8 +1,9 @@
 import pytest
 from fastapi import FastAPI
-from httpx import AsyncClient
+from httpx import AsyncClient, ASGITransport
 from app.src.controllers.items_controller import router, get_items_service
 from app.src.models.item import ItemCreate, ItemUpdate
+
 
 class FakeService:
     def __init__(self):
@@ -31,16 +32,19 @@ class FakeService:
 
     async def list(self, skip: int = 0, limit: int = 20):
         items = list(self._data.values())
-        return items[skip: skip + limit]
+        return items[skip : skip + limit]
 
-@pytest.mark.anyio
+
+@pytest.mark.anyio("asyncio")
 async def test_controller_crud():
     app = FastAPI()
+    svc = FakeService()
     # dependency override for tests
-    app.dependency_overrides[get_items_service] = lambda: FakeService()
+    app.dependency_overrides[get_items_service] = lambda: svc
     app.include_router(router, prefix="/api/v1/items")
 
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         # create
         resp = await ac.post("/api/v1/items", json={"name": "Pen", "description": "Blue"})
         assert resp.status_code == 200

--- a/app/tests/test_items_service.py
+++ b/app/tests/test_items_service.py
@@ -1,7 +1,7 @@
 import pytest
-import asyncio
 from app.src.models.item import ItemCreate, ItemUpdate
 from app.src.services.items_service import ItemsService
+
 
 class InMemoryRepo:
     def __init__(self):
@@ -28,9 +28,10 @@ class InMemoryRepo:
 
     async def list(self, *, skip: int = 0, limit: int = 20):
         items = list(self.store.values())
-        return items[skip: skip + limit]
+        return items[skip : skip + limit]
 
-@pytest.mark.anyio
+
+@pytest.mark.anyio("asyncio")
 async def test_service_create_and_get():
     repo = InMemoryRepo()
     svc = ItemsService(repo)  # type: ignore[arg-type]

--- a/app/tests/test_users_controller.py
+++ b/app/tests/test_users_controller.py
@@ -1,0 +1,41 @@
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+from app.src.controllers.users_controller import router, get_users_service
+from app.src.models.user import UserCreate
+
+
+class FakeService:
+    def __init__(self):
+        self._seq = 0
+        self._data = {}
+
+    async def create(self, payload: UserCreate) -> str:
+        self._seq += 1
+        _id = str(self._seq)
+        self._data[_id] = {"_id": _id, **payload.model_dump()}
+        return _id
+
+    async def get(self, user_id: str):
+        return self._data.get(user_id)
+
+
+@pytest.mark.anyio("asyncio")
+async def test_create_and_get_user():
+    app = FastAPI()
+    svc = FakeService()
+    app.dependency_overrides[get_users_service] = lambda: svc
+    app.include_router(router, prefix="/api/v1/users")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post(
+            "/api/v1/users",
+            json={"name": "Alice", "email": "alice@example.com"},
+        )
+        assert resp.status_code == 200
+        user_id = resp.json()
+        assert user_id == "1"
+
+        resp = await ac.get(f"/api/v1/users/{user_id}")
+        assert resp.status_code == 200
+        assert resp.json()["email"] == "alice@example.com"

--- a/app/tests/test_users_service.py
+++ b/app/tests/test_users_service.py
@@ -1,0 +1,30 @@
+import pytest
+from app.src.models.user import UserCreate
+from app.src.services.users_service import UsersService
+
+
+class InMemoryRepo:
+    def __init__(self):
+        self.store = {}
+        self._seq = 0
+
+    async def create(self, data: dict) -> str:
+        self._seq += 1
+        _id = str(self._seq)
+        self.store[_id] = {"_id": _id, **data}
+        return _id
+
+    async def get_by_id(self, id: str):
+        return self.store.get(id)
+
+
+@pytest.mark.anyio("asyncio")
+async def test_service_create_and_get():
+    repo = InMemoryRepo()
+    svc = UsersService(repo)  # type: ignore[arg-type]
+
+    user_id = await svc.create(UserCreate(name="Bob", email="bob@example.com"))
+    assert user_id == "1"
+
+    doc = await svc.get(user_id)
+    assert doc and doc["name"] == "Bob"


### PR DESCRIPTION
## Summary
- add /api/v1/users endpoints to create and fetch users in MongoDB
- wire up user service and repository
- refactor service layer to use repository protocol

## Testing
- `ruff check app/src/controllers/api_v1.py app/src/main.py app/src/services/items_service.py app/src/controllers/users_controller.py app/src/models/user.py app/src/services/repositories/mongo_users_repository.py app/src/services/users_service.py app/tests/test_items_controller.py app/tests/test_items_service.py app/tests/test_users_controller.py app/tests/test_users_service.py`
- `ANYIO_BACKENDS=asyncio PYTHONPATH=. pytest` *(fails: No module named 'trio')*


------
https://chatgpt.com/codex/tasks/task_e_68ba3cc131b8832f8cb12332e104dad7