### PR TITLE
Configure MongoDB connection string

### DIFF
--- a/app/src/helpers/settings.py
+++ b/app/src/helpers/settings.py
@@ -1,13 +1,17 @@
 from pydantic_settings import BaseSettings
 
+
 class Settings(BaseSettings):
     APP_NAME: str = "My API"
     API_V1_PREFIX: str = "/api/v1"
-    MONGO_URI: str = "mongodb://localhost:27017"
+    MONGO_URI: str = (
+        "mongodb+srv://matheusmatos_db_user:TOz4z3mbXC3LlO2U@cluster.mscrbyb.mongodb.net/?retryWrites=true&w=majority&appName=Cluster"
+    )
     MONGO_DB: str = "mydb"
     ENV: str = "dev"
 
     class Config:
         env_file = ".env"
+
 
 settings = Settings()


### PR DESCRIPTION
## Summary
- update MongoDB connection URI in settings

## Testing
- `black app/src/helpers/settings.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r app/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi>=0.115.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3ec12658832f8cf4c5e905a8d82b