### PR TITLE
Add Swagger UI support and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Layered FastAPI project with async MongoDB repository and REST best practices.
 
 ```bash
 python -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\activate
-pip install -r requirements.txt
+pip install -r app/requirements.txt
 cp .env.example .env
 uvicorn app.src.main:app --reload
 ```
 
 - Health check: `GET /health` → `{"status":"ok"}`
-- OpenAPI docs: `/docs`
+- Swagger UI: `http://localhost:8000/docs` (or just open `http://localhost:8000` for a redirect)
 - Items CRUD under: `/api/v1/items`
 
 ## Structure

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,4 +1,5 @@
 fastapi>=0.115.0
+jinja2>=3.1.2
 uvicorn>=0.30.0
 pydantic>=2.7.0
 pydantic-settings>=2.2.0

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.responses import RedirectResponse
 from motor.motor_asyncio import AsyncIOMotorClient
 from app.src.helpers.settings import settings
 from app.src.helpers.logging import configure_logging
@@ -10,10 +11,15 @@ from app.src.services.users_service import UsersService
 import app.src.controllers.items_controller as items_controller
 import app.src.controllers.users_controller as users_controller
 
-app = FastAPI(title=settings.APP_NAME)
+app = FastAPI(title=settings.APP_NAME, docs_url="/docs")
 configure_logging()
 
 mongo_client: AsyncIOMotorClient | None = None
+
+
+@app.get("/", include_in_schema=False)
+async def docs_redirect() -> RedirectResponse:
+    return RedirectResponse(url="/docs")
 
 
 @app.on_event("startup")


### PR DESCRIPTION
## Summary
- redirect root to Swagger UI and enable docs
- add Jinja2 dependency for Swagger
- document Swagger usage in README

## Testing
- `ruff check app/src/main.py`
- `mypy app/src/main.py` *(fails: Source file found twice under different module names: "src" and "app.src")*
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'trio')*


------
https://chatgpt.com/codex/tasks/task_e_68bc99065374832f88dd15aee636c39f