### PR TITLE
Add optional TLS CA configuration for Mongo client

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ tests/
 ## Notes
 - Simple DI wiring sets a singleton `ItemsService` at startup.
 - Swap storage by implementing a new repository matching `RepositoryProtocol`.
+- Configure MongoDB TLS trust by setting `MONGO_TLS_CA_FILE` (defaults to the `certifi` bundle when available).

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -4,6 +4,7 @@ uvicorn>=0.30.0
 pydantic>=2.7.0
 pydantic-settings>=2.2.0
 motor>=3.5.0
+certifi>=2024.2.2
 pytest>=8.0.0
 httpx>=0.27.0
 ruff>=0.5.0

--- a/app/src/helpers/settings.py
+++ b/app/src/helpers/settings.py
@@ -1,4 +1,18 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import Field
 from pydantic_settings import BaseSettings
+
+
+def _default_tls_ca_file() -> Optional[str]:
+    try:
+        import certifi  # type: ignore import-not-found
+    except ModuleNotFoundError:
+        return None
+
+    return certifi.where()
 
 
 class Settings(BaseSettings):
@@ -8,6 +22,7 @@ class Settings(BaseSettings):
         "mongodb+srv://matheusmatos_db_user:TOz4z3mbXC3LlO2U@cluster.mscrbyb.mongodb.net/?retryWrites=true&w=majority&appName=Cluster"
     )
     MONGO_DB: str = "mydb"
+    MONGO_TLS_CA_FILE: str | None = Field(default_factory=_default_tls_ca_file)
     ENV: str = "dev"
 
     class Config:

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -25,7 +25,11 @@ async def docs_redirect() -> RedirectResponse:
 @app.on_event("startup")
 async def startup() -> None:
     global mongo_client
-    mongo_client = AsyncIOMotorClient(settings.MONGO_URI)
+    client_options: dict[str, object] = {}
+    if settings.MONGO_TLS_CA_FILE:
+        client_options["tlsCAFile"] = settings.MONGO_TLS_CA_FILE
+
+    mongo_client = AsyncIOMotorClient(settings.MONGO_URI, **client_options)
     items_repo = MongoItemsRepository(mongo_client, settings.MONGO_DB)
     items_svc = ItemsService(items_repo)
     users_repo = MongoUsersRepository(mongo_client, settings.MONGO_DB)


### PR DESCRIPTION
## Summary
- add a `MONGO_TLS_CA_FILE` setting that defaults to the `certifi` CA bundle when the dependency is available
- forward the optional TLS CA file to `AsyncIOMotorClient` so the driver can validate the MongoDB server with custom trust stores
- document the new TLS CA configuration option in the project README and include the `certifi` dependency for convenience

## Testing
- pytest *(fails: missing dependencies such as fastapi and the app package in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb5360934832f85097d35af543075