### PR TITLE
feat: add companies controller and service

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ uvicorn app.src.main:app --reload
 - Health check: `GET /health` → `{"status":"ok"}`
 - Swagger UI: `http://localhost:8000/docs` (or just open `http://localhost:8000` for a redirect)
 - Items CRUD under: `/api/v1/items`
+- Users endpoints under: `/api/v1/users`
+- Companies CRUD under: `/api/v1/companies`
+
+### Empresas (Companies) payload
+
+| Campo         | Tipo   | Descrição                                                 |
+| ------------- | ------ | --------------------------------------------------------- |
+| `id`          | string | ID única da empresa (ex: `cli_001`)                       |
+| `nome`        | string | Nome da empresa                                           |
+| `cnpj`        | string | CNPJ da empresa                                           |
+| `setor`       | string | Setor de atuação (ex: Tecnologia, Saúde)                  |
+| `localizacao` | string | Cidade e estado                                           |
+| `criado_em`   | date   | Data de cadastro da empresa (ISO 8601, ex: `2024-01-31`) |
+| `vagas`       | array  | Lista de vagas abertas ou já encerradas                  |
 
 ## Structure
 
@@ -28,5 +42,5 @@ tests/
 ```
 
 ## Notes
-- Simple DI wiring sets a singleton `ItemsService` at startup.
+- Simple DI wiring sets singleton services (items, users, companies) at startup.
 - Swap storage by implementing a new repository matching `RepositoryProtocol`.

--- a/app/src/controllers/api_v1.py
+++ b/app/src/controllers/api_v1.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter
+from app.src.controllers.companies_controller import router as companies_router
 from app.src.controllers.items_controller import router as items_router
 from app.src.controllers.users_controller import router as users_router
 
 api_router = APIRouter()
 api_router.include_router(items_router, prefix="/items", tags=["items"])
 api_router.include_router(users_router, prefix="/users", tags=["users"])
+api_router.include_router(companies_router, prefix="/companies", tags=["companies"])

--- a/app/src/controllers/companies_controller.py
+++ b/app/src/controllers/companies_controller.py
@@ -1,8 +1,8 @@
-from datetime import date, datetime
 from typing import Callable, List, Optional
 
 from fastapi import APIRouter, Depends, Query
 
+from app.src.helpers.format_data import FormatData
 from app.src.helpers.pagination import Pagination
 from app.src.models.company import CompanyCreate, CompanyOut, CompanyUpdate
 from app.src.services.companies_service import CompaniesService
@@ -19,24 +19,6 @@ def get_companies_service() -> CompaniesService:
     return companies_service_provider()
 
 
-def _to_company_out(doc: dict) -> CompanyOut:
-    company_id = str(doc.get("_id") or doc.get("id"))
-    criado_em_value = doc.get("criado_em")
-    if isinstance(criado_em_value, str):
-        criado_em_value = date.fromisoformat(criado_em_value)
-    elif isinstance(criado_em_value, datetime):
-        criado_em_value = criado_em_value.date()
-    return CompanyOut(
-        id=company_id,
-        nome=doc["nome"],
-        cnpj=doc["cnpj"],
-        setor=doc["setor"],
-        localizacao=doc["localizacao"],
-        criado_em=criado_em_value,
-        vagas=doc["vagas"],
-    )
-
-
 @router.post("", response_model=str)
 async def create_company(
     payload: CompanyCreate, svc: CompaniesService = Depends(get_companies_service)
@@ -49,7 +31,7 @@ async def get_company(
     company_id: str, svc: CompaniesService = Depends(get_companies_service)
 ) -> CompanyOut | None:
     doc = await svc.get(company_id)
-    return None if not doc else _to_company_out(doc)
+    return None if not doc else FormatData.company_out(doc)
 
 
 @router.put("/{company_id}", response_model=bool)
@@ -76,4 +58,4 @@ async def list_companies(
 ) -> List[CompanyOut]:
     pg = Pagination.clamp(skip, limit)
     docs = await svc.list(skip=pg.skip, limit=pg.limit)
-    return [_to_company_out(d) for d in docs]
+    return [FormatData.company_out(d) for d in docs]

--- a/app/src/controllers/companies_controller.py
+++ b/app/src/controllers/companies_controller.py
@@ -1,0 +1,79 @@
+from datetime import date, datetime
+from typing import Callable, List, Optional
+
+from fastapi import APIRouter, Depends, Query
+
+from app.src.helpers.pagination import Pagination
+from app.src.models.company import CompanyCreate, CompanyOut, CompanyUpdate
+from app.src.services.companies_service import CompaniesService
+
+router = APIRouter()
+
+# Provider placeholder wired at runtime in app.src.main
+companies_service_provider: Optional[Callable[[], CompaniesService]] = None
+
+
+def get_companies_service() -> CompaniesService:
+    if companies_service_provider is None:  # pragma: no cover - wired at runtime
+        raise RuntimeError("CompaniesService provider not wired. Configure at startup.")
+    return companies_service_provider()
+
+
+def _to_company_out(doc: dict) -> CompanyOut:
+    company_id = str(doc.get("_id") or doc.get("id"))
+    criado_em_value = doc.get("criado_em")
+    if isinstance(criado_em_value, str):
+        criado_em_value = date.fromisoformat(criado_em_value)
+    elif isinstance(criado_em_value, datetime):
+        criado_em_value = criado_em_value.date()
+    return CompanyOut(
+        id=company_id,
+        nome=doc["nome"],
+        cnpj=doc["cnpj"],
+        setor=doc["setor"],
+        localizacao=doc["localizacao"],
+        criado_em=criado_em_value,
+        vagas=doc["vagas"],
+    )
+
+
+@router.post("", response_model=str)
+async def create_company(
+    payload: CompanyCreate, svc: CompaniesService = Depends(get_companies_service)
+) -> str:
+    return await svc.create(payload)
+
+
+@router.get("/{company_id}", response_model=CompanyOut | None)
+async def get_company(
+    company_id: str, svc: CompaniesService = Depends(get_companies_service)
+) -> CompanyOut | None:
+    doc = await svc.get(company_id)
+    return None if not doc else _to_company_out(doc)
+
+
+@router.put("/{company_id}", response_model=bool)
+async def update_company(
+    company_id: str,
+    payload: CompanyUpdate,
+    svc: CompaniesService = Depends(get_companies_service),
+) -> bool:
+    return await svc.update(company_id, payload)
+
+
+@router.delete("/{company_id}", response_model=bool)
+async def delete_company(
+    company_id: str, svc: CompaniesService = Depends(get_companies_service)
+) -> bool:
+    return await svc.delete(company_id)
+
+
+@router.get("", response_model=List[CompanyOut])
+async def list_companies(
+    skip: int = Query(default=0, ge=0),
+    limit: int = Query(default=20, ge=1, le=100),
+    svc: CompaniesService = Depends(get_companies_service),
+) -> List[CompanyOut]:
+    pg = Pagination.clamp(skip, limit)
+    docs = await svc.list(skip=pg.skip, limit=pg.limit)
+    return [_to_company_out(d) for d in docs]

--- a/app/src/helpers/format_data.py
+++ b/app/src/helpers/format_data.py
@@ -1,0 +1,28 @@
+from datetime import date, datetime
+
+from app.src.models.company import CompanyOut
+
+
+class FormatData:
+    """Utility helpers to map raw persistence documents into API models."""
+
+    @staticmethod
+    def company_out(doc: dict) -> CompanyOut:
+        """Normalize a persistence document into ``CompanyOut`` payload."""
+        company_id = str(doc.get("_id") or doc.get("id"))
+        criado_em_value = doc.get("criado_em")
+
+        if isinstance(criado_em_value, str):
+            criado_em_value = date.fromisoformat(criado_em_value)
+        elif isinstance(criado_em_value, datetime):
+            criado_em_value = criado_em_value.date()
+
+        return CompanyOut(
+            id=company_id,
+            nome=doc["nome"],
+            cnpj=doc["cnpj"],
+            setor=doc["setor"],
+            localizacao=doc["localizacao"],
+            criado_em=criado_em_value,
+            vagas=doc["vagas"],
+        )

--- a/app/src/helpers/utils.py
+++ b/app/src/helpers/utils.py
@@ -1,0 +1,13 @@
+from datetime import date, datetime
+from typing import Any, Dict
+
+
+def coerce_dates_for_bson(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy with date values converted to naive datetimes for BSON."""
+    coerced: Dict[str, Any] = {}
+    for key, value in data.items():
+        if isinstance(value, date) and not isinstance(value, datetime):
+            coerced[key] = datetime.combine(value, datetime.min.time())
+        else:
+            coerced[key] = value
+    return coerced

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -4,12 +4,15 @@ from motor.motor_asyncio import AsyncIOMotorClient
 from app.src.helpers.settings import settings
 from app.src.helpers.logging import configure_logging
 from app.src.controllers.api_v1 import api_router
+from app.src.services.repositories.mongo_companies_repository import MongoCompaniesRepository
 from app.src.services.repositories.mongo_items_repository import MongoItemsRepository
 from app.src.services.items_service import ItemsService
 from app.src.services.repositories.mongo_users_repository import MongoUsersRepository
 from app.src.services.users_service import UsersService
+from app.src.services.companies_service import CompaniesService
 import app.src.controllers.items_controller as items_controller
 import app.src.controllers.users_controller as users_controller
+import app.src.controllers.companies_controller as companies_controller
 
 app = FastAPI(title=settings.APP_NAME, docs_url="/docs")
 configure_logging()
@@ -30,6 +33,8 @@ async def startup() -> None:
     items_svc = ItemsService(items_repo)
     users_repo = MongoUsersRepository(mongo_client, settings.MONGO_DB)
     users_svc = UsersService(users_repo)
+    companies_repo = MongoCompaniesRepository(mongo_client, settings.MONGO_DB)
+    companies_svc = CompaniesService(companies_repo)
 
     def _items_provider() -> ItemsService:
         return items_svc
@@ -37,9 +42,13 @@ async def startup() -> None:
     def _users_provider() -> UsersService:
         return users_svc
 
+    def _companies_provider() -> CompaniesService:
+        return companies_svc
+
     # simple dependency injection via provider variables
     items_controller.items_service_provider = _items_provider  # type: ignore[attr-defined]
     users_controller.users_service_provider = _users_provider  # type: ignore[attr-defined]
+    companies_controller.companies_service_provider = _companies_provider  # type: ignore[attr-defined]
 
 
 @app.on_event("shutdown")

--- a/app/src/models/company.py
+++ b/app/src/models/company.py
@@ -1,0 +1,30 @@
+from datetime import date
+from typing import List
+
+from app.src.models.base import APIModel
+
+
+class CompanyBase(APIModel):
+    nome: str
+    cnpj: str
+    setor: str
+    localizacao: str
+    criado_em: date
+    vagas: List[str]
+
+
+class CompanyCreate(CompanyBase):
+    id: str
+
+
+class CompanyUpdate(APIModel):
+    nome: str | None = None
+    cnpj: str | None = None
+    setor: str | None = None
+    localizacao: str | None = None
+    criado_em: date | None = None
+    vagas: List[str] | None = None
+
+
+class CompanyOut(CompanyBase):
+    id: str

--- a/app/src/services/companies_service.py
+++ b/app/src/services/companies_service.py
@@ -1,0 +1,28 @@
+from typing import Any, Dict, List
+
+from app.src.domain.repositories import RepositoryProtocol
+from app.src.models.company import CompanyCreate, CompanyUpdate
+
+
+class CompaniesService:
+    def __init__(self, repo: RepositoryProtocol):
+        self.repo = repo
+
+    async def create(self, payload: CompanyCreate) -> str:
+        data = payload.model_dump()
+        return await self.repo.create(data)
+
+    async def get(self, company_id: str) -> Dict[str, Any] | None:
+        return await self.repo.get_by_id(company_id)
+
+    async def update(self, company_id: str, payload: CompanyUpdate) -> bool:
+        data = {k: v for k, v in payload.model_dump().items() if v is not None}
+        if not data:
+            return True
+        return await self.repo.update(company_id, data)
+
+    async def delete(self, company_id: str) -> bool:
+        return await self.repo.delete(company_id)
+
+    async def list(self, skip: int = 0, limit: int = 20) -> List[Dict[str, Any]]:
+        return await self.repo.list(skip=skip, limit=limit)

--- a/app/src/services/repositories/mongo_companies_repository.py
+++ b/app/src/services/repositories/mongo_companies_repository.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional
 from bson import ObjectId
 from motor.motor_asyncio import AsyncIOMotorClient
 
+from app.src.helpers.utils import coerce_dates_for_bson
 
 class MongoCompaniesRepository:
     def __init__(self, client: AsyncIOMotorClient, db_name: str):
@@ -23,7 +24,7 @@ class MongoCompaniesRepository:
         return await self._col.find_one({"_id": object_id})
 
     async def create(self, data: Dict[str, Any]) -> str:
-        payload = data.copy()
+        payload = coerce_dates_for_bson(data)
         company_id = payload.pop("id", None)
         if company_id is not None:
             payload["_id"] = company_id
@@ -31,14 +32,15 @@ class MongoCompaniesRepository:
         return str(res.inserted_id)
 
     async def update(self, id: str, data: Dict[str, Any]) -> bool:
-        res = await self._col.update_one({"_id": id}, {"$set": data})
+        payload = coerce_dates_for_bson(data)
+        res = await self._col.update_one({"_id": id}, {"$set": payload})
         if res.matched_count:
-            return res.modified_count > 0 or bool(data)
+            return res.modified_count > 0 or bool(payload)
         try:
             object_id = ObjectId(id)
         except Exception:
             return False
-        res = await self._col.update_one({"_id": object_id}, {"$set": data})
+        res = await self._col.update_one({"_id": object_id}, {"$set": payload})
         return res.modified_count > 0 or res.matched_count > 0
 
     async def delete(self, id: str) -> bool:

--- a/app/src/services/repositories/mongo_companies_repository.py
+++ b/app/src/services/repositories/mongo_companies_repository.py
@@ -1,0 +1,57 @@
+from typing import Any, Dict, List, Optional
+
+from bson import ObjectId
+from motor.motor_asyncio import AsyncIOMotorClient
+
+
+class MongoCompaniesRepository:
+    def __init__(self, client: AsyncIOMotorClient, db_name: str):
+        self._db = client[db_name]
+        self._col = self._db["companies"]
+
+    async def get_by_id(self, id: str) -> Optional[Dict[str, Any]]:
+        # companies use the provided string id when available, but we also
+        # support ObjectId lookup to keep behaviour consistent with other
+        # collections.
+        doc = await self._col.find_one({"_id": id})
+        if doc:
+            return doc
+        try:
+            object_id = ObjectId(id)
+        except Exception:
+            return None
+        return await self._col.find_one({"_id": object_id})
+
+    async def create(self, data: Dict[str, Any]) -> str:
+        payload = data.copy()
+        company_id = payload.pop("id", None)
+        if company_id is not None:
+            payload["_id"] = company_id
+        res = await self._col.insert_one(payload)
+        return str(res.inserted_id)
+
+    async def update(self, id: str, data: Dict[str, Any]) -> bool:
+        res = await self._col.update_one({"_id": id}, {"$set": data})
+        if res.matched_count:
+            return res.modified_count > 0 or bool(data)
+        try:
+            object_id = ObjectId(id)
+        except Exception:
+            return False
+        res = await self._col.update_one({"_id": object_id}, {"$set": data})
+        return res.modified_count > 0 or res.matched_count > 0
+
+    async def delete(self, id: str) -> bool:
+        res = await self._col.delete_one({"_id": id})
+        if res.deleted_count:
+            return True
+        try:
+            object_id = ObjectId(id)
+        except Exception:
+            return False
+        res = await self._col.delete_one({"_id": object_id})
+        return res.deleted_count > 0
+
+    async def list(self, *, skip: int = 0, limit: int = 20) -> List[Dict[str, Any]]:
+        cursor = self._col.find().skip(skip).limit(limit)
+        return [doc async for doc in cursor]

--- a/app/tests/test_companies_controller.py
+++ b/app/tests/test_companies_controller.py
@@ -1,0 +1,79 @@
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.src.controllers.companies_controller import (
+    get_companies_service,
+    router,
+)
+from app.src.models.company import CompanyCreate, CompanyUpdate
+
+
+class FakeService:
+    def __init__(self):
+        self._data: dict[str, dict] = {}
+
+    async def create(self, payload: CompanyCreate) -> str:
+        self._data[payload.id] = {"_id": payload.id, **payload.model_dump(exclude={"id"})}
+        return payload.id
+
+    async def get(self, company_id: str):
+        return self._data.get(company_id)
+
+    async def update(self, company_id: str, payload: CompanyUpdate) -> bool:
+        if company_id not in self._data:
+            return False
+        for field, value in payload.model_dump().items():
+            if value is not None:
+                self._data[company_id][field] = value
+        return True
+
+    async def delete(self, company_id: str) -> bool:
+        return self._data.pop(company_id, None) is not None
+
+    async def list(self, skip: int = 0, limit: int = 20):
+        companies = list(self._data.values())
+        return companies[skip : skip + limit]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_companies_controller_crud_flow():
+    app = FastAPI()
+    svc = FakeService()
+    app.dependency_overrides[get_companies_service] = lambda: svc
+    app.include_router(router, prefix="/api/v1/companies")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        payload = {
+            "id": "cli_001",
+            "nome": "Tech Corp",
+            "cnpj": "11.111.111/0001-11",
+            "setor": "Tecnologia",
+            "localizacao": "Rio de Janeiro/RJ",
+            "criado_em": "2024-02-01",
+            "vagas": ["Backend", "Frontend"],
+        }
+
+        resp = await ac.post("/api/v1/companies", json=payload)
+        assert resp.status_code == 200
+        assert resp.json() == "cli_001"
+
+        resp = await ac.get("/api/v1/companies/cli_001")
+        assert resp.status_code == 200
+        assert resp.json()["nome"] == "Tech Corp"
+
+        resp = await ac.get("/api/v1/companies")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+
+        resp = await ac.put(
+            "/api/v1/companies/cli_001",
+            json={"setor": "Finanças", "vagas": ["Analista"]},
+        )
+        assert resp.status_code == 200
+        assert resp.json() is True
+
+        resp = await ac.delete("/api/v1/companies/cli_001")
+        assert resp.status_code == 200
+        assert resp.json() is True

--- a/app/tests/test_companies_service.py
+++ b/app/tests/test_companies_service.py
@@ -1,0 +1,61 @@
+import pytest
+
+from app.src.models.company import CompanyCreate, CompanyUpdate
+from app.src.services.companies_service import CompaniesService
+
+
+class InMemoryRepo:
+    def __init__(self):
+        self.store = {}
+
+    async def get_by_id(self, id: str):
+        return self.store.get(id)
+
+    async def create(self, data: dict) -> str:
+        company_id = data["id"]
+        self.store[company_id] = {"_id": company_id, **{k: v for k, v in data.items() if k != "id"}}
+        return company_id
+
+    async def update(self, id: str, data: dict) -> bool:
+        if id not in self.store:
+            return False
+        self.store[id].update(data)
+        return True
+
+    async def delete(self, id: str) -> bool:
+        return self.store.pop(id, None) is not None
+
+    async def list(self, *, skip: int = 0, limit: int = 20):
+        items = list(self.store.values())
+        return items[skip : skip + limit]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_companies_service_crud_flow():
+    repo = InMemoryRepo()
+    svc = CompaniesService(repo)  # type: ignore[arg-type]
+
+    company_id = await svc.create(
+        CompanyCreate(
+            id="cli_001",
+            nome="Acme",
+            cnpj="00.000.000/0000-00",
+            setor="Tecnologia",
+            localizacao="São Paulo/SP",
+            criado_em="2024-01-01",
+            vagas=["Dev", "QA"],
+        )
+    )
+    assert company_id == "cli_001"
+
+    fetched = await svc.get(company_id)
+    assert fetched and fetched["nome"] == "Acme"
+
+    updated = await svc.update(company_id, CompanyUpdate(setor="Fintech"))
+    assert updated
+
+    listed = await svc.list()
+    assert len(listed) == 1
+
+    deleted = await svc.delete(company_id)
+    assert deleted


### PR DESCRIPTION
## Summary
- add company models, repository, service and controller with CRUD routes
- register companies endpoints and dependency wiring in the application startup
- cover the new layer with unit tests and extend the README with payload details

## Testing
- pytest *(fails: missing FastAPI dependency in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d33ca55238832f8d7df21899e97bd6