### PR TITLE
Add vagas controller, service, and repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ uvicorn app.src.main:app --reload
 - Items CRUD under: `/api/v1/items`
 - Users endpoints under: `/api/v1/users`
 - Companies CRUD under: `/api/v1/companies`
+- Vagas CRUD under: `/api/v1/vagas`
 
 ### Empresas (Companies) payload
 
@@ -28,6 +29,19 @@ uvicorn app.src.main:app --reload
 | `localizacao` | string | Cidade e estado                                           |
 | `criado_em`   | date   | Data de cadastro da empresa (ISO 8601, ex: `2024-01-31`) |
 | `vagas`       | array  | Lista de vagas abertas ou já encerradas                  |
+
+### Vagas payload
+
+| Campo           | Tipo   | Descrição                                                                 |
+| --------------- | ------ | ------------------------------------------------------------------------- |
+| `client_id`     | string | Referência para a empresa responsável pela vaga                          |
+| `titulo`        | string | Título da vaga (ex: `Analista de Dados`)                                  |
+| `descricao`     | string | Descrição detalhada das atividades                                       |
+| `nivel`         | string | Nível da vaga (ex: Júnior, Pleno, Sênior)                                 |
+| `localizacao`   | string | Local da vaga (cidade, estado ou `Remoto`)                                |
+| `publicada_em`  | date   | Data de publicação (ISO 8601, ex: `2024-03-10`)                            |
+| `status`        | string | Situação atual da vaga (ex: Aberta, Fechada, Em análise)                  |
+| `skills`        | array  | Lista de habilidades desejadas (ex: `["Python", "AWS", "Testes"]`)        |
 
 ## Structure
 

--- a/app/src/controllers/api_v1.py
+++ b/app/src/controllers/api_v1.py
@@ -2,8 +2,10 @@ from fastapi import APIRouter
 from app.src.controllers.companies_controller import router as companies_router
 from app.src.controllers.items_controller import router as items_router
 from app.src.controllers.users_controller import router as users_router
+from app.src.controllers.vagas_controller import router as vagas_router
 
 api_router = APIRouter()
 api_router.include_router(items_router, prefix="/items", tags=["items"])
 api_router.include_router(users_router, prefix="/users", tags=["users"])
 api_router.include_router(companies_router, prefix="/companies", tags=["companies"])
+api_router.include_router(vagas_router, prefix="/vagas", tags=["vagas"])

--- a/app/src/controllers/vagas_controller.py
+++ b/app/src/controllers/vagas_controller.py
@@ -1,0 +1,53 @@
+from typing import Callable, List, Optional
+
+from fastapi import APIRouter, Depends, Query
+
+from app.src.helpers.format_data import FormatData
+from app.src.helpers.pagination import Pagination
+from app.src.models.vaga import VagaCreate, VagaOut, VagaUpdate
+from app.src.services.vagas_service import VagasService
+
+router = APIRouter()
+
+# Provider placeholder wired at runtime in app.src.main
+vagas_service_provider: Optional[Callable[[], VagasService]] = None
+
+
+def get_vagas_service() -> VagasService:
+    if vagas_service_provider is None:  # pragma: no cover - wired at runtime
+        raise RuntimeError("VagasService provider not wired. Configure at startup.")
+    return vagas_service_provider()
+
+
+@router.post("", response_model=str)
+async def create_vaga(payload: VagaCreate, svc: VagasService = Depends(get_vagas_service)) -> str:
+    return await svc.create(payload)
+
+
+@router.get("/{vaga_id}", response_model=VagaOut | None)
+async def get_vaga(vaga_id: str, svc: VagasService = Depends(get_vagas_service)) -> VagaOut | None:
+    doc = await svc.get(vaga_id)
+    return None if not doc else FormatData.vaga_out(doc)
+
+
+@router.put("/{vaga_id}", response_model=bool)
+async def update_vaga(
+    vaga_id: str, payload: VagaUpdate, svc: VagasService = Depends(get_vagas_service)
+) -> bool:
+    return await svc.update(vaga_id, payload)
+
+
+@router.delete("/{vaga_id}", response_model=bool)
+async def delete_vaga(vaga_id: str, svc: VagasService = Depends(get_vagas_service)) -> bool:
+    return await svc.delete(vaga_id)
+
+
+@router.get("", response_model=List[VagaOut])
+async def list_vagas(
+    skip: int = Query(default=0, ge=0),
+    limit: int = Query(default=20, ge=1, le=100),
+    svc: VagasService = Depends(get_vagas_service),
+) -> List[VagaOut]:
+    pg = Pagination.clamp(skip, limit)
+    docs = await svc.list(skip=pg.skip, limit=pg.limit)
+    return [FormatData.vaga_out(d) for d in docs]

--- a/app/src/helpers/format_data.py
+++ b/app/src/helpers/format_data.py
@@ -1,6 +1,7 @@
 from datetime import date, datetime
 
 from app.src.models.company import CompanyOut
+from app.src.models.vaga import VagaOut
 
 
 class FormatData:
@@ -25,4 +26,27 @@ class FormatData:
             localizacao=doc["localizacao"],
             criado_em=criado_em_value,
             vagas=doc["vagas"],
+        )
+
+    @staticmethod
+    def vaga_out(doc: dict) -> VagaOut:
+        """Normalize a persistence document into ``VagaOut`` payload."""
+        vaga_id = str(doc.get("_id") or doc.get("id"))
+        publicada_em_value = doc.get("publicada_em")
+
+        if isinstance(publicada_em_value, str):
+            publicada_em_value = date.fromisoformat(publicada_em_value)
+        elif isinstance(publicada_em_value, datetime):
+            publicada_em_value = publicada_em_value.date()
+
+        return VagaOut(
+            id=vaga_id,
+            client_id=doc["client_id"],
+            titulo=doc["titulo"],
+            descricao=doc["descricao"],
+            nivel=doc["nivel"],
+            localizacao=doc["localizacao"],
+            publicada_em=publicada_em_value,
+            status=doc["status"],
+            skills=doc.get("skills", []),
         )

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -6,13 +6,16 @@ from app.src.helpers.logging import configure_logging
 from app.src.controllers.api_v1 import api_router
 from app.src.services.repositories.mongo_companies_repository import MongoCompaniesRepository
 from app.src.services.repositories.mongo_items_repository import MongoItemsRepository
-from app.src.services.items_service import ItemsService
 from app.src.services.repositories.mongo_users_repository import MongoUsersRepository
+from app.src.services.repositories.mongo_vagas_repository import MongoVagasRepository
+from app.src.services.items_service import ItemsService
 from app.src.services.users_service import UsersService
 from app.src.services.companies_service import CompaniesService
+from app.src.services.vagas_service import VagasService
 import app.src.controllers.items_controller as items_controller
 import app.src.controllers.users_controller as users_controller
 import app.src.controllers.companies_controller as companies_controller
+import app.src.controllers.vagas_controller as vagas_controller
 
 app = FastAPI(title=settings.APP_NAME, docs_url="/docs")
 configure_logging()
@@ -35,6 +38,8 @@ async def startup() -> None:
     users_svc = UsersService(users_repo)
     companies_repo = MongoCompaniesRepository(mongo_client, settings.MONGO_DB)
     companies_svc = CompaniesService(companies_repo)
+    vagas_repo = MongoVagasRepository(mongo_client, settings.MONGO_DB)
+    vagas_svc = VagasService(vagas_repo)
 
     def _items_provider() -> ItemsService:
         return items_svc
@@ -45,10 +50,14 @@ async def startup() -> None:
     def _companies_provider() -> CompaniesService:
         return companies_svc
 
+    def _vagas_provider() -> VagasService:
+        return vagas_svc
+
     # simple dependency injection via provider variables
     items_controller.items_service_provider = _items_provider  # type: ignore[attr-defined]
     users_controller.users_service_provider = _users_provider  # type: ignore[attr-defined]
     companies_controller.companies_service_provider = _companies_provider  # type: ignore[attr-defined]
+    vagas_controller.vagas_service_provider = _vagas_provider  # type: ignore[attr-defined]
 
 
 @app.on_event("shutdown")

--- a/app/src/models/vaga.py
+++ b/app/src/models/vaga.py
@@ -1,0 +1,34 @@
+from datetime import date
+from typing import List
+
+from app.src.models.base import APIModel
+
+
+class VagaBase(APIModel):
+    client_id: str
+    titulo: str
+    descricao: str
+    nivel: str
+    localizacao: str
+    publicada_em: date
+    status: str
+    skills: List[str]
+
+
+class VagaCreate(VagaBase):
+    pass
+
+
+class VagaUpdate(APIModel):
+    client_id: str | None = None
+    titulo: str | None = None
+    descricao: str | None = None
+    nivel: str | None = None
+    localizacao: str | None = None
+    publicada_em: date | None = None
+    status: str | None = None
+    skills: List[str] | None = None
+
+
+class VagaOut(VagaBase):
+    id: str

--- a/app/src/services/repositories/mongo_vagas_repository.py
+++ b/app/src/services/repositories/mongo_vagas_repository.py
@@ -1,0 +1,54 @@
+from typing import Any, Dict, List, Optional
+
+from bson import ObjectId
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from app.src.helpers.utils import coerce_dates_for_bson
+
+
+class MongoVagasRepository:
+    def __init__(self, client: AsyncIOMotorClient, db_name: str):
+        self._db = client[db_name]
+        self._col = self._db["vagas"]
+
+    async def get_by_id(self, id: str) -> Optional[Dict[str, Any]]:
+        doc = await self._col.find_one({"_id": id})
+        if doc:
+            return doc
+        try:
+            object_id = ObjectId(id)
+        except Exception:
+            return None
+        return await self._col.find_one({"_id": object_id})
+
+    async def create(self, data: Dict[str, Any]) -> str:
+        payload = coerce_dates_for_bson(data)
+        res = await self._col.insert_one(payload)
+        return str(res.inserted_id)
+
+    async def update(self, id: str, data: Dict[str, Any]) -> bool:
+        payload = coerce_dates_for_bson(data)
+        res = await self._col.update_one({"_id": id}, {"$set": payload})
+        if res.matched_count:
+            return res.modified_count > 0 or bool(payload)
+        try:
+            object_id = ObjectId(id)
+        except Exception:
+            return False
+        res = await self._col.update_one({"_id": object_id}, {"$set": payload})
+        return res.modified_count > 0 or res.matched_count > 0
+
+    async def delete(self, id: str) -> bool:
+        res = await self._col.delete_one({"_id": id})
+        if res.deleted_count:
+            return True
+        try:
+            object_id = ObjectId(id)
+        except Exception:
+            return False
+        res = await self._col.delete_one({"_id": object_id})
+        return res.deleted_count > 0
+
+    async def list(self, *, skip: int = 0, limit: int = 20) -> List[Dict[str, Any]]:
+        cursor = self._col.find().skip(skip).limit(limit)
+        return [doc async for doc in cursor]

--- a/app/src/services/vagas_service.py
+++ b/app/src/services/vagas_service.py
@@ -1,0 +1,28 @@
+from typing import Any, Dict, List
+
+from app.src.domain.repositories import RepositoryProtocol
+from app.src.models.vaga import VagaCreate, VagaUpdate
+
+
+class VagasService:
+    def __init__(self, repo: RepositoryProtocol):
+        self.repo = repo
+
+    async def create(self, payload: VagaCreate) -> str:
+        data = payload.model_dump()
+        return await self.repo.create(data)
+
+    async def get(self, vaga_id: str) -> Dict[str, Any] | None:
+        return await self.repo.get_by_id(vaga_id)
+
+    async def update(self, vaga_id: str, payload: VagaUpdate) -> bool:
+        data = {k: v for k, v in payload.model_dump().items() if v is not None}
+        if not data:
+            return True
+        return await self.repo.update(vaga_id, data)
+
+    async def delete(self, vaga_id: str) -> bool:
+        return await self.repo.delete(vaga_id)
+
+    async def list(self, skip: int = 0, limit: int = 20) -> List[Dict[str, Any]]:
+        return await self.repo.list(skip=skip, limit=limit)

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"

--- a/app/tests/demo_vagas_requests.py
+++ b/app/tests/demo_vagas_requests.py
@@ -1,0 +1,94 @@
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.append(str(ROOT_DIR))
+
+from app.src.controllers.vagas_controller import get_vagas_service, router
+from app.src.models.vaga import VagaCreate, VagaUpdate
+
+
+class InMemoryVagasService:
+    """Simple in-memory service used to demonstrate the vagas endpoints."""
+
+    def __init__(self) -> None:
+        self._data: Dict[str, Dict[str, Any]] = {}
+        self._counter = 0
+
+    async def create(self, payload: VagaCreate) -> str:
+        self._counter += 1
+        vaga_id = f"vaga_{self._counter:03d}"
+        self._data[vaga_id] = {"_id": vaga_id, **payload.model_dump()}
+        return vaga_id
+
+    async def get(self, vaga_id: str) -> Dict[str, Any] | None:
+        return self._data.get(vaga_id)
+
+    async def update(self, vaga_id: str, payload: VagaUpdate) -> bool:
+        if vaga_id not in self._data:
+            return False
+        for field, value in payload.model_dump().items():
+            if value is not None:
+                self._data[vaga_id][field] = value
+        return True
+
+    async def delete(self, vaga_id: str) -> bool:
+        return self._data.pop(vaga_id, None) is not None
+
+    async def list(self, skip: int = 0, limit: int = 20) -> List[Dict[str, Any]]:
+        vagas = list(self._data.values())
+        return vagas[skip : skip + limit]
+
+
+def format_json(payload: Any) -> str:
+    return json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True)
+
+
+def build_app() -> FastAPI:
+    app = FastAPI()
+    service = InMemoryVagasService()
+    app.dependency_overrides[get_vagas_service] = lambda: service
+    app.include_router(router, prefix="/api/v1/vagas")
+    return app
+
+
+async def run_demo() -> None:
+    app = build_app()
+    transport = ASGITransport(app=app)
+
+    payload = {
+        "client_id": "cli_001",
+        "titulo": "Analista de Dados",
+        "descricao": "Responsável por relatórios e dashboards.",
+        "nivel": "Senior",
+        "localizacao": "Remoto",
+        "publicada_em": "2024-03-10",
+        "status": "Aberta",
+        "skills": ["Python", "AWS", "Testes"],
+    }
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        post_response = await client.post("/api/v1/vagas", json=payload)
+        get_all_response = await client.get("/api/v1/vagas")
+
+    print("POST /api/v1/vagas payload:")
+    print(format_json(payload))
+    print()
+    print("POST response status:", post_response.status_code)
+    print("POST response body:")
+    print(format_json(post_response.json()))
+    print()
+    print("GET /api/v1/vagas response status:", get_all_response.status_code)
+    print("GET /api/v1/vagas response body:")
+    print(format_json(get_all_response.json()))
+
+
+if __name__ == "__main__":
+    asyncio.run(run_demo())

--- a/app/tests/test_vagas_controller.py
+++ b/app/tests/test_vagas_controller.py
@@ -1,0 +1,81 @@
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.src.controllers.vagas_controller import get_vagas_service, router
+from app.src.models.vaga import VagaCreate, VagaUpdate
+
+
+class FakeService:
+    def __init__(self):
+        self._data: dict[str, dict] = {}
+        self._counter = 0
+
+    async def create(self, payload: VagaCreate) -> str:
+        self._counter += 1
+        vaga_id = f"vaga_{self._counter:03d}"
+        self._data[vaga_id] = {"_id": vaga_id, **payload.model_dump()}
+        return vaga_id
+
+    async def get(self, vaga_id: str):
+        return self._data.get(vaga_id)
+
+    async def update(self, vaga_id: str, payload: VagaUpdate) -> bool:
+        if vaga_id not in self._data:
+            return False
+        for field, value in payload.model_dump().items():
+            if value is not None:
+                self._data[vaga_id][field] = value
+        return True
+
+    async def delete(self, vaga_id: str) -> bool:
+        return self._data.pop(vaga_id, None) is not None
+
+    async def list(self, skip: int = 0, limit: int = 20):
+        vagas = list(self._data.values())
+        return vagas[skip : skip + limit]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_vagas_controller_crud_flow():
+    app = FastAPI()
+    svc = FakeService()
+    app.dependency_overrides[get_vagas_service] = lambda: svc
+    app.include_router(router, prefix="/api/v1/vagas")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        payload = {
+            "client_id": "cli_001",
+            "titulo": "Analista de Dados",
+            "descricao": "Responsável por relatórios.",
+            "nivel": "Senior",
+            "localizacao": "Remoto",
+            "publicada_em": "2024-03-10",
+            "status": "Aberta",
+            "skills": ["Python", "AWS"],
+        }
+
+        resp = await ac.post("/api/v1/vagas", json=payload)
+        assert resp.status_code == 200
+        vaga_id = resp.json()
+        assert vaga_id == "vaga_001"
+
+        resp = await ac.get(f"/api/v1/vagas/{vaga_id}")
+        assert resp.status_code == 200
+        assert resp.json()["titulo"] == "Analista de Dados"
+
+        resp = await ac.get("/api/v1/vagas")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+
+        resp = await ac.put(
+            f"/api/v1/vagas/{vaga_id}",
+            json={"status": "Fechada", "skills": ["Python", "SQL"]},
+        )
+        assert resp.status_code == 200
+        assert resp.json() is True
+
+        resp = await ac.delete(f"/api/v1/vagas/{vaga_id}")
+        assert resp.status_code == 200
+        assert resp.json() is True

--- a/app/tests/test_vagas_service.py
+++ b/app/tests/test_vagas_service.py
@@ -1,0 +1,63 @@
+import pytest
+
+from app.src.models.vaga import VagaCreate, VagaUpdate
+from app.src.services.vagas_service import VagasService
+
+
+class InMemoryRepo:
+    def __init__(self):
+        self.store: dict[str, dict] = {}
+
+    async def get_by_id(self, id: str):
+        return self.store.get(id)
+
+    async def create(self, data: dict) -> str:
+        vaga_id = f"vaga_{len(self.store) + 1:03d}"
+        self.store[vaga_id] = {"_id": vaga_id, **data}
+        return vaga_id
+
+    async def update(self, id: str, data: dict) -> bool:
+        if id not in self.store:
+            return False
+        self.store[id].update(data)
+        return True
+
+    async def delete(self, id: str) -> bool:
+        return self.store.pop(id, None) is not None
+
+    async def list(self, *, skip: int = 0, limit: int = 20):
+        items = list(self.store.values())
+        return items[skip : skip + limit]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_vagas_service_crud_flow():
+    repo = InMemoryRepo()
+    svc = VagasService(repo)  # type: ignore[arg-type]
+
+    vaga_id = await svc.create(
+        VagaCreate(
+            client_id="cli_001",
+            titulo="Analista de Dados",
+            descricao="Responsável por analisar dados.",
+            nivel="Pleno",
+            localizacao="São Paulo/SP",
+            publicada_em="2024-03-10",
+            status="Aberta",
+            skills=["Python", "SQL"],
+        )
+    )
+
+    assert vaga_id == "vaga_001"
+
+    fetched = await svc.get(vaga_id)
+    assert fetched and fetched["titulo"] == "Analista de Dados"
+
+    updated = await svc.update(vaga_id, VagaUpdate(status="Fechada"))
+    assert updated
+
+    listed = await svc.list()
+    assert len(listed) == 1
+
+    deleted = await svc.delete(vaga_id)
+    assert deleted


### PR DESCRIPTION
## Summary
- add Vaga models, service layer, Mongo repository, and controller wired into the FastAPI app
- expose `/api/v1/vagas` CRUD endpoints and data mappers alongside existing routers
- document Vagas payload details and cover the new flow with controller/service tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5e6385710832fb694b3b2af239ba3