### PR TITLE
Add candidatura resource API

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ uvicorn app.src.main:app --reload
 - Items CRUD under: `/api/v1/items`
 - Users endpoints under: `/api/v1/users`
 - Companies CRUD under: `/api/v1/companies`
+- Candidaturas CRUD under: `/api/v1/candidaturas`
 
 ### Empresas (Companies) payload
 
@@ -28,6 +29,29 @@ uvicorn app.src.main:app --reload
 | `localizacao` | string | Cidade e estado                                           |
 | `criado_em`   | date   | Data de cadastro da empresa (ISO 8601, ex: `2024-01-31`) |
 | `vagas`       | array  | Lista de vagas abertas ou já encerradas                  |
+
+### Candidaturas payload
+
+| Campo                 | Tipo         | Descrição                                                             |
+| --------------------- | ------------ | --------------------------------------------------------------------- |
+| `company_id`          | string       | Identificador único da empresa associada                              |
+| `name`                | string       | Nome da empresa                                                       |
+| `email`               | string       | E-mail corporativo usado para login e contato                         |
+| `password_hash`       | string       | Hash da senha para autenticação                                       |
+| `phone`               | string       | Telefone de contato                                                   |
+| `website`             | string (URL) | Website oficial                                                       |
+| `location.city`       | string       | Cidade onde a empresa está localizada                                 |
+| `location.state`      | string       | Estado onde a empresa está localizada                                 |
+| `location.country`    | string       | País onde a empresa está localizada                                   |
+| `about`               | string       | Descrição da empresa                                                  |
+| `industry`            | string       | Setor de atuação (ex: Tecnologia, Saúde)                              |
+| `size`                | string       | Tamanho da empresa (ex: `1-10`, `11-50`, `201-500`)                   |
+| `founded_year`        | number       | Ano de fundação                                                       |
+| `social_links.linkedin` | string (URL) | Link para o LinkedIn corporativo                                      |
+| `social_links.instagram` | string (URL) | Link para o Instagram corporativo                                     |
+| `logo_url`            | string (URL) | URL com o logo da empresa                                             |
+| `created_at`          | string (ISO 8601) | Data de criação do cadastro                                        |
+| `updated_at`          | string (ISO 8601) | Data da última atualização do cadastro                              |
 
 ## Structure
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+# Makes ``app`` a package for test imports.

--- a/app/src/controllers/api_v1.py
+++ b/app/src/controllers/api_v1.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter
+from app.src.controllers.candidaturas_controller import router as candidaturas_router
 from app.src.controllers.companies_controller import router as companies_router
 from app.src.controllers.items_controller import router as items_router
 from app.src.controllers.users_controller import router as users_router
@@ -7,3 +8,4 @@ api_router = APIRouter()
 api_router.include_router(items_router, prefix="/items", tags=["items"])
 api_router.include_router(users_router, prefix="/users", tags=["users"])
 api_router.include_router(companies_router, prefix="/companies", tags=["companies"])
+api_router.include_router(candidaturas_router, prefix="/candidaturas", tags=["candidaturas"])

--- a/app/src/controllers/candidaturas_controller.py
+++ b/app/src/controllers/candidaturas_controller.py
@@ -1,0 +1,61 @@
+from typing import Callable, List, Optional
+
+from fastapi import APIRouter, Depends, Query
+
+from app.src.helpers.format_data import FormatData
+from app.src.helpers.pagination import Pagination
+from app.src.models.candidatura import CandidaturaCreate, CandidaturaOut, CandidaturaUpdate
+from app.src.services.candidaturas_service import CandidaturasService
+
+router = APIRouter()
+
+# Provider placeholder wired at runtime in app.src.main
+candidaturas_service_provider: Optional[Callable[[], CandidaturasService]] = None
+
+
+def get_candidaturas_service() -> CandidaturasService:
+    if candidaturas_service_provider is None:  # pragma: no cover - wired at runtime
+        raise RuntimeError("CandidaturasService provider not wired. Configure at startup.")
+    return candidaturas_service_provider()
+
+
+@router.post("", response_model=str)
+async def create_candidatura(
+    payload: CandidaturaCreate, svc: CandidaturasService = Depends(get_candidaturas_service)
+) -> str:
+    return await svc.create(payload)
+
+
+@router.get("/{company_id}", response_model=CandidaturaOut | None)
+async def get_candidatura(
+    company_id: str, svc: CandidaturasService = Depends(get_candidaturas_service)
+) -> CandidaturaOut | None:
+    doc = await svc.get(company_id)
+    return None if not doc else FormatData.candidatura_out(doc)
+
+
+@router.put("/{company_id}", response_model=bool)
+async def update_candidatura(
+    company_id: str,
+    payload: CandidaturaUpdate,
+    svc: CandidaturasService = Depends(get_candidaturas_service),
+) -> bool:
+    return await svc.update(company_id, payload)
+
+
+@router.delete("/{company_id}", response_model=bool)
+async def delete_candidatura(
+    company_id: str, svc: CandidaturasService = Depends(get_candidaturas_service)
+) -> bool:
+    return await svc.delete(company_id)
+
+
+@router.get("", response_model=List[CandidaturaOut])
+async def list_candidaturas(
+    skip: int = Query(default=0, ge=0),
+    limit: int = Query(default=20, ge=1, le=100),
+    svc: CandidaturasService = Depends(get_candidaturas_service),
+) -> List[CandidaturaOut]:
+    pg = Pagination.clamp(skip, limit)
+    docs = await svc.list(skip=pg.skip, limit=pg.limit)
+    return [FormatData.candidatura_out(d) for d in docs]

--- a/app/src/helpers/format_data.py
+++ b/app/src/helpers/format_data.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime
 
+from app.src.models.candidatura import CandidaturaOut
 from app.src.models.company import CompanyOut
 
 
@@ -25,4 +26,42 @@ class FormatData:
             localizacao=doc["localizacao"],
             criado_em=criado_em_value,
             vagas=doc["vagas"],
+        )
+
+    @staticmethod
+    def _parse_datetime(value: datetime | str | None) -> datetime | None:
+        if value is None or isinstance(value, datetime):
+            return value
+        iso_value = value
+        if iso_value.endswith("Z"):
+            iso_value = iso_value[:-1] + "+00:00"
+        return datetime.fromisoformat(iso_value)
+
+    @staticmethod
+    def candidatura_out(doc: dict) -> CandidaturaOut:
+        """Normalize a persistence document into ``CandidaturaOut`` payload."""
+        company_id = str(doc.get("_id") or doc.get("company_id"))
+
+        created_at_value = FormatData._parse_datetime(doc.get("created_at"))
+        updated_at_value = FormatData._parse_datetime(doc.get("updated_at"))
+
+        location = doc.get("location") or {}
+        social_links = doc.get("social_links") or {}
+
+        return CandidaturaOut(
+            company_id=company_id,
+            name=doc["name"],
+            email=doc["email"],
+            password_hash=doc["password_hash"],
+            phone=doc["phone"],
+            website=doc["website"],
+            location=location,
+            about=doc["about"],
+            industry=doc["industry"],
+            size=doc["size"],
+            founded_year=doc["founded_year"],
+            social_links=social_links,
+            logo_url=doc["logo_url"],
+            created_at=created_at_value,
+            updated_at=updated_at_value,
         )

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -4,15 +4,20 @@ from motor.motor_asyncio import AsyncIOMotorClient
 from app.src.helpers.settings import settings
 from app.src.helpers.logging import configure_logging
 from app.src.controllers.api_v1 import api_router
+from app.src.services.repositories.mongo_candidaturas_repository import (
+    MongoCandidaturasRepository,
+)
 from app.src.services.repositories.mongo_companies_repository import MongoCompaniesRepository
 from app.src.services.repositories.mongo_items_repository import MongoItemsRepository
 from app.src.services.items_service import ItemsService
 from app.src.services.repositories.mongo_users_repository import MongoUsersRepository
 from app.src.services.users_service import UsersService
+from app.src.services.candidaturas_service import CandidaturasService
 from app.src.services.companies_service import CompaniesService
 import app.src.controllers.items_controller as items_controller
 import app.src.controllers.users_controller as users_controller
 import app.src.controllers.companies_controller as companies_controller
+import app.src.controllers.candidaturas_controller as candidaturas_controller
 
 app = FastAPI(title=settings.APP_NAME, docs_url="/docs")
 configure_logging()
@@ -35,6 +40,8 @@ async def startup() -> None:
     users_svc = UsersService(users_repo)
     companies_repo = MongoCompaniesRepository(mongo_client, settings.MONGO_DB)
     companies_svc = CompaniesService(companies_repo)
+    candidaturas_repo = MongoCandidaturasRepository(mongo_client, settings.MONGO_DB)
+    candidaturas_svc = CandidaturasService(candidaturas_repo)
 
     def _items_provider() -> ItemsService:
         return items_svc
@@ -45,10 +52,14 @@ async def startup() -> None:
     def _companies_provider() -> CompaniesService:
         return companies_svc
 
+    def _candidaturas_provider() -> CandidaturasService:
+        return candidaturas_svc
+
     # simple dependency injection via provider variables
     items_controller.items_service_provider = _items_provider  # type: ignore[attr-defined]
     users_controller.users_service_provider = _users_provider  # type: ignore[attr-defined]
     companies_controller.companies_service_provider = _companies_provider  # type: ignore[attr-defined]
+    candidaturas_controller.candidaturas_service_provider = _candidaturas_provider  # type: ignore[attr-defined]
 
 
 @app.on_event("shutdown")

--- a/app/src/models/candidatura.py
+++ b/app/src/models/candidatura.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+
+from app.src.models.base import APIModel
+
+
+class ApplicationLocation(APIModel):
+    city: str
+    state: str
+    country: str
+
+
+class ApplicationSocialLinks(APIModel):
+    linkedin: str | None = None
+    instagram: str | None = None
+
+
+class CandidaturaBase(APIModel):
+    company_id: str
+    name: str
+    email: str
+    password_hash: str
+    phone: str
+    website: str
+    location: ApplicationLocation
+    about: str
+    industry: str
+    size: str
+    founded_year: int
+    social_links: ApplicationSocialLinks
+    logo_url: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class CandidaturaCreate(CandidaturaBase):
+    pass
+
+
+class CandidaturaUpdate(APIModel):
+    name: str | None = None
+    email: str | None = None
+    password_hash: str | None = None
+    phone: str | None = None
+    website: str | None = None
+    location: ApplicationLocation | None = None
+    about: str | None = None
+    industry: str | None = None
+    size: str | None = None
+    founded_year: int | None = None
+    social_links: ApplicationSocialLinks | None = None
+    logo_url: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class CandidaturaOut(CandidaturaBase):
+    pass

--- a/app/src/services/candidaturas_service.py
+++ b/app/src/services/candidaturas_service.py
@@ -1,0 +1,28 @@
+from typing import Any, Dict, List
+
+from app.src.domain.repositories import RepositoryProtocol
+from app.src.models.candidatura import CandidaturaCreate, CandidaturaUpdate
+
+
+class CandidaturasService:
+    def __init__(self, repo: RepositoryProtocol):
+        self.repo = repo
+
+    async def create(self, payload: CandidaturaCreate) -> str:
+        data = payload.model_dump()
+        return await self.repo.create(data)
+
+    async def get(self, company_id: str) -> Dict[str, Any] | None:
+        return await self.repo.get_by_id(company_id)
+
+    async def update(self, company_id: str, payload: CandidaturaUpdate) -> bool:
+        data = payload.model_dump(exclude_none=True)
+        if not data:
+            return True
+        return await self.repo.update(company_id, data)
+
+    async def delete(self, company_id: str) -> bool:
+        return await self.repo.delete(company_id)
+
+    async def list(self, skip: int = 0, limit: int = 20) -> List[Dict[str, Any]]:
+        return await self.repo.list(skip=skip, limit=limit)

--- a/app/src/services/repositories/mongo_candidaturas_repository.py
+++ b/app/src/services/repositories/mongo_candidaturas_repository.py
@@ -1,0 +1,57 @@
+from typing import Any, Dict, List, Optional
+
+from bson import ObjectId
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from app.src.helpers.utils import coerce_dates_for_bson
+
+
+class MongoCandidaturasRepository:
+    def __init__(self, client: AsyncIOMotorClient, db_name: str):
+        self._db = client[db_name]
+        self._col = self._db["candidaturas"]
+
+    async def get_by_id(self, id: str) -> Optional[Dict[str, Any]]:
+        doc = await self._col.find_one({"_id": id})
+        if doc:
+            return doc
+        try:
+            object_id = ObjectId(id)
+        except Exception:
+            return None
+        return await self._col.find_one({"_id": object_id})
+
+    async def create(self, data: Dict[str, Any]) -> str:
+        payload = coerce_dates_for_bson(data)
+        company_id = payload.get("company_id")
+        if company_id is not None:
+            payload["_id"] = company_id
+        res = await self._col.insert_one(payload)
+        return str(res.inserted_id)
+
+    async def update(self, id: str, data: Dict[str, Any]) -> bool:
+        payload = coerce_dates_for_bson(data)
+        res = await self._col.update_one({"_id": id}, {"$set": payload})
+        if res.matched_count:
+            return res.modified_count > 0 or bool(payload)
+        try:
+            object_id = ObjectId(id)
+        except Exception:
+            return False
+        res = await self._col.update_one({"_id": object_id}, {"$set": payload})
+        return res.modified_count > 0 or res.matched_count > 0
+
+    async def delete(self, id: str) -> bool:
+        res = await self._col.delete_one({"_id": id})
+        if res.deleted_count:
+            return True
+        try:
+            object_id = ObjectId(id)
+        except Exception:
+            return False
+        res = await self._col.delete_one({"_id": object_id})
+        return res.deleted_count > 0
+
+    async def list(self, *, skip: int = 0, limit: int = 20) -> List[Dict[str, Any]]:
+        cursor = self._col.find().skip(skip).limit(limit)
+        return [doc async for doc in cursor]

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/app/tests/test_candidaturas_controller.py
+++ b/app/tests/test_candidaturas_controller.py
@@ -1,0 +1,98 @@
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.src.controllers.candidaturas_controller import (
+    get_candidaturas_service,
+    router,
+)
+from app.src.models.candidatura import CandidaturaCreate, CandidaturaUpdate
+
+
+class FakeService:
+    def __init__(self):
+        self._data: dict[str, dict] = {}
+
+    async def create(self, payload: CandidaturaCreate) -> str:
+        self._data[payload.company_id] = {
+            "_id": payload.company_id,
+            **payload.model_dump(exclude={"company_id"}),
+            "company_id": payload.company_id,
+        }
+        return payload.company_id
+
+    async def get(self, company_id: str):
+        return self._data.get(company_id)
+
+    async def update(self, company_id: str, payload: CandidaturaUpdate) -> bool:
+        if company_id not in self._data:
+            return False
+        for field, value in payload.model_dump().items():
+            if value is not None:
+                self._data[company_id][field] = value
+        return True
+
+    async def delete(self, company_id: str) -> bool:
+        return self._data.pop(company_id, None) is not None
+
+    async def list(self, skip: int = 0, limit: int = 20):
+        candidaturas = list(self._data.values())
+        return candidaturas[skip : skip + limit]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_candidaturas_controller_crud_flow():
+    app = FastAPI()
+    svc = FakeService()
+    app.dependency_overrides[get_candidaturas_service] = lambda: svc
+    app.include_router(router, prefix="/api/v1/candidaturas")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        payload = {
+            "company_id": "comp_001",
+            "name": "Tech Corp",
+            "email": "contact@techcorp.com",
+            "password_hash": "hashedpwd",
+            "phone": "+55 11 99999-9999",
+            "website": "https://techcorp.com",
+            "location": {
+                "city": "São Paulo",
+                "state": "SP",
+                "country": "Brasil",
+            },
+            "about": "Empresa de tecnologia focada em IA.",
+            "industry": "Tecnologia",
+            "size": "51-100",
+            "founded_year": 2015,
+            "social_links": {
+                "linkedin": "https://linkedin.com/company/techcorp",
+                "instagram": "https://instagram.com/techcorp",
+            },
+            "logo_url": "https://cdn.techcorp.com/logo.png",
+            "created_at": "2024-01-10T10:00:00",
+            "updated_at": "2024-01-10T10:00:00",
+        }
+
+        resp = await ac.post("/api/v1/candidaturas", json=payload)
+        assert resp.status_code == 200
+        assert resp.json() == "comp_001"
+
+        resp = await ac.get("/api/v1/candidaturas/comp_001")
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Tech Corp"
+
+        resp = await ac.get("/api/v1/candidaturas")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+
+        resp = await ac.put(
+            "/api/v1/candidaturas/comp_001",
+            json={"size": "101-200"},
+        )
+        assert resp.status_code == 200
+        assert resp.json() is True
+
+        resp = await ac.delete("/api/v1/candidaturas/comp_001")
+        assert resp.status_code == 200
+        assert resp.json() is True

--- a/app/tests/test_candidaturas_service.py
+++ b/app/tests/test_candidaturas_service.py
@@ -1,0 +1,76 @@
+import pytest
+
+from app.src.models.candidatura import CandidaturaCreate, CandidaturaUpdate
+from app.src.services.candidaturas_service import CandidaturasService
+
+
+class InMemoryRepo:
+    def __init__(self):
+        self.store = {}
+
+    async def get_by_id(self, id: str):
+        return self.store.get(id)
+
+    async def create(self, data: dict) -> str:
+        company_id = data["company_id"]
+        self.store[company_id] = {"_id": company_id, **data}
+        return company_id
+
+    async def update(self, id: str, data: dict) -> bool:
+        if id not in self.store:
+            return False
+        self.store[id].update(data)
+        return True
+
+    async def delete(self, id: str) -> bool:
+        return self.store.pop(id, None) is not None
+
+    async def list(self, *, skip: int = 0, limit: int = 20):
+        items = list(self.store.values())
+        return items[skip : skip + limit]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_candidaturas_service_crud_flow():
+    repo = InMemoryRepo()
+    svc = CandidaturasService(repo)  # type: ignore[arg-type]
+
+    payload = CandidaturaCreate(
+        company_id="comp_001",
+        name="Tech Corp",
+        email="contact@techcorp.com",
+        password_hash="hashedpwd",
+        phone="+55 11 99999-9999",
+        website="https://techcorp.com",
+        location={
+            "city": "São Paulo",
+            "state": "SP",
+            "country": "Brasil",
+        },
+        about="Empresa de tecnologia focada em IA.",
+        industry="Tecnologia",
+        size="51-100",
+        founded_year=2015,
+        social_links={
+            "linkedin": "https://linkedin.com/company/techcorp",
+            "instagram": "https://instagram.com/techcorp",
+        },
+        logo_url="https://cdn.techcorp.com/logo.png",
+        created_at="2024-01-10T10:00:00",
+        updated_at="2024-01-10T10:00:00",
+    )
+
+    created_id = await svc.create(payload)
+    assert created_id == "comp_001"
+
+    fetched = await svc.get(created_id)
+    assert fetched and fetched["name"] == "Tech Corp"
+
+    updated = await svc.update(created_id, CandidaturaUpdate(size="101-200"))
+    assert updated
+
+    listed = await svc.list()
+    assert len(listed) == 1
+
+    deleted = await svc.delete(created_id)
+    assert deleted


### PR DESCRIPTION
## Summary
- add REST controller, models, service, and Mongo repository for candidaturas management
- expose candidatura routes in the API router and DI setup, including helper formatting support
- extend documentation and automated tests for the new candidature resource

## Testing
- `pytest` *(fails: missing fastapi/pydantic dependencies – package installation blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d5e85581c0832fabf00b4e5a6bcde5