### PR TITLE
docs: update API documentation for applications endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,32 @@ uvicorn app.src.main:app --reload
 
 - Health check: `GET /health` → `{"status":"ok"}`
 - Swagger UI: `http://localhost:8000/docs` (or just open `http://localhost:8000` for a redirect)
-- Items CRUD under: `/api/v1/items`
 - Users endpoints under: `/api/v1/users`
 - Companies CRUD under: `/api/v1/companies`
-- Candidaturas CRUD under: `/api/v1/candidaturas`
+- Applications CRUD under: `/api/v1/applications`
+- Jobs CRUD under: `/api/v1/vagas`
+- Use the interactive docs at `http://localhost:8000/docs` to inspect every endpoint's
+  request and response schema (click **Try it out** → **Execute** for live examples).
+
+## Inspecting request/response payloads
+
+FastAPI ships with interactive documentation that lets you validate the payloads for
+each operation without writing any code.
+
+1. Start the server (`uvicorn app.src.main:app --reload`).
+2. Open `http://localhost:8000/docs` for Swagger UI (or `http://localhost:8000/redoc`).
+3. Select an endpoint, press **Try it out**, fill the body/query parameters and
+   execute the call.
+4. Swagger UI shows the exact request sent and the formatted response payload,
+   making it easy to verify the contract for every route.
+
+If you prefer the terminal, you can capture the request/response pairs with `curl`
+or `httpie`. Example for the companies listing:
+
+```bash
+curl -X GET http://localhost:8000/api/v1/companies | jq
+```
+
 
 ### Empresas (Companies) payload
 
@@ -30,41 +52,41 @@ uvicorn app.src.main:app --reload
 | `criado_em`   | date   | Data de cadastro da empresa (ISO 8601, ex: `2024-01-31`) |
 | `vagas`       | array  | Lista de vagas abertas ou já encerradas                  |
 
-### Candidaturas payload
+### Applications payload
 
 | Campo                 | Tipo         | Descrição                                                             |
 | --------------------- | ------------ | --------------------------------------------------------------------- |
-| `company_id`          | string       | Identificador único da empresa associada                              |
-| `name`                | string       | Nome da empresa                                                       |
-| `email`               | string       | E-mail corporativo usado para login e contato                         |
-| `password_hash`       | string       | Hash da senha para autenticação                                       |
-| `phone`               | string       | Telefone de contato                                                   |
-| `website`             | string (URL) | Website oficial                                                       |
-| `location.city`       | string       | Cidade onde a empresa está localizada                                 |
-| `location.state`      | string       | Estado onde a empresa está localizada                                 |
-| `location.country`    | string       | País onde a empresa está localizada                                   |
-| `about`               | string       | Descrição da empresa                                                  |
-| `industry`            | string       | Setor de atuação (ex: Tecnologia, Saúde)                              |
-| `size`                | string       | Tamanho da empresa (ex: `1-10`, `11-50`, `201-500`)                   |
-| `founded_year`        | number       | Ano de fundação                                                       |
-| `social_links.linkedin` | string (URL) | Link para o LinkedIn corporativo                                      |
-| `social_links.instagram` | string (URL) | Link para o Instagram corporativo                                     |
-| `logo_url`            | string (URL) | URL com o logo da empresa                                             |
-| `created_at`          | string (ISO 8601) | Data de criação do cadastro                                        |
-| `updated_at`          | string (ISO 8601) | Data da última atualização do cadastro                              |
+| `company_id`          | string       | Unique identifier for the company associated with the application     |
+| `name`                | string       | Company name                                                          |
+| `email`               | string       | Corporate e-mail used for login and contact                           |
+| `password_hash`       | string       | Password hash used for authentication                                 |
+| `phone`               | string       | Contact phone number                                                  |
+| `website`             | string (URL) | Official website                                                      |
+| `location.city`       | string       | City where the company is located                                     |
+| `location.state`      | string       | State where the company is located                                    |
+| `location.country`    | string       | Country where the company is located                                  |
+| `about`               | string       | Company description                                                   |
+| `industry`            | string       | Industry sector (e.g. Technology, Healthcare)                         |
+| `size`                | string       | Company size (e.g. `1-10`, `11-50`, `201-500`)                        |
+| `founded_year`        | number       | Year the company was founded                                          |
+| `social_links.linkedin` | string (URL) | Link to the corporate LinkedIn profile                                |
+| `social_links.instagram` | string (URL) | Link to the corporate Instagram profile                               |
+| `logo_url`            | string (URL) | URL with the company logo                                             |
+| `created_at`          | string (ISO 8601) | Date the application profile was created                            |
+| `updated_at`          | string (ISO 8601) | Date the application profile was last updated                       |
 
-### Vagas payload
+### Job openings payload
 
 | Campo           | Tipo   | Descrição                                                                 |
 | --------------- | ------ | ------------------------------------------------------------------------- |
 | `client_id`     | string | Referência para a empresa responsável pela vaga                          |
-| `titulo`        | string | Título da vaga (ex: `Analista de Dados`)                                  |
-| `descricao`     | string | Descrição detalhada das atividades                                       |
-| `nivel`         | string | Nível da vaga (ex: Júnior, Pleno, Sênior)                                 |
-| `localizacao`   | string | Local da vaga (cidade, estado ou `Remoto`)                                |
-| `publicada_em`  | date   | Data de publicação (ISO 8601, ex: `2024-03-10`)                            |
-| `status`        | string | Situação atual da vaga (ex: Aberta, Fechada, Em análise)                  |
-| `skills`        | array  | Lista de habilidades desejadas (ex: `["Python", "AWS", "Testes"]`)        |
+| `titulo`        | string | Job title (e.g. `Analista de Dados`)                                     |
+| `descricao`     | string | Detailed description of the activities                                   |
+| `nivel`         | string | Job level (e.g. Junior, Mid, Senior)                                     |
+| `localizacao`   | string | Job location (city/state or `Remote`)                                    |
+| `publicada_em`  | date   | Publication date (ISO 8601, e.g. `2024-03-10`)                            |
+| `status`        | string | Current status (e.g. Open, Closed, Under review)                          |
+| `skills`        | array  | Desired skills (e.g. `["Python", "AWS", "Testing"]`)                      |
 
 
 ## Structure

--- a/app/src/controllers/api_v1.py
+++ b/app/src/controllers/api_v1.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from app.src.controllers.candidaturas_controller import router as candidaturas_router
+from app.src.controllers.candidaturas_controller import router as applications_router
 from app.src.controllers.companies_controller import router as companies_router
 from app.src.controllers.items_controller import router as items_router
 from app.src.controllers.users_controller import router as users_router
@@ -9,5 +9,5 @@ api_router = APIRouter()
 api_router.include_router(items_router, prefix="/items", tags=["items"])
 api_router.include_router(users_router, prefix="/users", tags=["users"])
 api_router.include_router(companies_router, prefix="/companies", tags=["companies"])
-api_router.include_router(candidaturas_router, prefix="/candidaturas", tags=["candidaturas"])
+api_router.include_router(applications_router, prefix="/applications", tags=["applications"])
 api_router.include_router(vagas_router, prefix="/vagas", tags=["vagas"])

--- a/app/tests/test_candidaturas_controller.py
+++ b/app/tests/test_candidaturas_controller.py
@@ -45,7 +45,7 @@ async def test_candidaturas_controller_crud_flow():
     app = FastAPI()
     svc = FakeService()
     app.dependency_overrides[get_candidaturas_service] = lambda: svc
-    app.include_router(router, prefix="/api/v1/candidaturas")
+    app.include_router(router, prefix="/api/v1/applications")
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
@@ -74,25 +74,25 @@ async def test_candidaturas_controller_crud_flow():
             "updated_at": "2024-01-10T10:00:00",
         }
 
-        resp = await ac.post("/api/v1/candidaturas", json=payload)
+        resp = await ac.post("/api/v1/applications", json=payload)
         assert resp.status_code == 200
         assert resp.json() == "comp_001"
 
-        resp = await ac.get("/api/v1/candidaturas/comp_001")
+        resp = await ac.get("/api/v1/applications/comp_001")
         assert resp.status_code == 200
         assert resp.json()["name"] == "Tech Corp"
 
-        resp = await ac.get("/api/v1/candidaturas")
+        resp = await ac.get("/api/v1/applications")
         assert resp.status_code == 200
         assert len(resp.json()) == 1
 
         resp = await ac.put(
-            "/api/v1/candidaturas/comp_001",
+            "/api/v1/applications/comp_001",
             json={"size": "101-200"},
         )
         assert resp.status_code == 200
         assert resp.json() is True
 
-        resp = await ac.delete("/api/v1/candidaturas/comp_001")
+        resp = await ac.delete("/api/v1/applications/comp_001")
         assert resp.status_code == 200
         assert resp.json() is True


### PR DESCRIPTION
## Summary
- document how to inspect request and response payloads using FastAPI's interactive docs
- remove the deprecated /api/v1/items mention and describe the applications endpoints in English
- switch the applications router to /api/v1/applications and adjust tests accordingly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eefa132f0c832fac17f2473264294f